### PR TITLE
ci: publish to npm on GitHub release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,46 @@
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Release tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build 🔧
+        run: npm run build
+
+      - name: Publish 🚀
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Adds a `publish.yaml` workflow aligned with [tiptap-comment-extension](https://github.com/sereneinserenade/tiptap-comment-extension/blob/main/.github/workflows/publish.yaml).

**Behavior**
- Triggers when a GitHub Release is published.
- Uses Node 22.14.0, `npm ci`, `npm run build`, then `npm publish --provenance --access public`.
- Fails the job if the release tag (with optional `v` prefix) does not match `package.json` `version`.
- `id-token: write` enables npm provenance via OIDC when the package is configured with a [trusted publisher](https://docs.npmjs.com/trusted-publishers) for this repository.

If OIDC is not set up on npm yet, configure the trusted publisher for `sereneinserenade/tiptap-search-and-replace` or add an `NPM_TOKEN` and adjust the publish step to use `NODE_AUTH_TOKEN`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GitHub Actions workflow that runs only on release publishing and doesn’t change runtime/library code. Main risk is accidental/failed releases if the tag/version check or npm trusted publishing setup is misconfigured.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/publish.yaml`) to publish the package to npm when a GitHub Release is published.
> 
> The job sets up Node `22.14.0`, upgrades npm for OIDC trusted publishing, verifies the release tag (optionally prefixed with `v`) matches `package.json`’s `version`, then runs `npm ci`, `npm run build`, and `npm publish --provenance --access public` with `id-token: write` permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09bf35dd0b6c447483055e835b98b48ddb54cb63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->